### PR TITLE
FIX: Only exclude directories when searching for tes3 plugins

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -314,7 +314,7 @@ where
         plugins.for_each(|p| {
             if let Ok(file) = p {
                 let file_path = file.path();
-                if file_path.is_file() {
+                if !file_path.is_dir() {
                     if let Some(ext_os) = file_path.extension() {
                         let ext = ext_os.to_ascii_lowercase();
                         if ext == "esm"


### PR DESCRIPTION
I was speaking to a user in openmw discord who was trying my new vfstool, and they reported PLOX doesn't recognize collapsed directories at all: https://discord.com/channels/260439894298460160/995021436924203199/1368463129515917395

It seems as though plox just doesn't support links, maybe on accident, so I changed the filter here to omit directories instead of explicitly checking for a file. The rust docs seem to corroborate `is_file` will return false for link types on Windows, but I didn't look particularly close.